### PR TITLE
Switched RHC12 to SMD except for the BTA part

### DIFF
--- a/RHC12-BTA.brd
+++ b/RHC12-BTA.brd
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!DOCTYPE eagle SYSTEM "eagle.dtd">
-<eagle version="7.5.0">
+<eagle version="7.2.0">
 <drawing>
 <settings>
 <setting alwaysvectorfont="no"/>
@@ -200,17 +200,25 @@ We've spent an enormous amount of time creating and checking these footprints an
 <text x="-2.92" y="-7.07" size="1.27" layer="25">&gt;NAME</text>
 <wire x1="-8" y1="-5.1" x2="7.9" y2="-5.1" width="0.2032" layer="21"/>
 </package>
-<package name="1X04_NO_SILK_ALL_ROUND">
-<pad name="1" x="0" y="0" drill="1.016" diameter="1.8796" rot="R90"/>
-<pad name="2" x="2.54" y="0" drill="1.016" diameter="1.8796" rot="R90"/>
-<pad name="3" x="5.08" y="0" drill="1.016" diameter="1.8796" rot="R90"/>
-<pad name="4" x="7.62" y="0" drill="1.016" diameter="1.8796" rot="R90"/>
-<text x="-1.3462" y="1.8288" size="1.27" layer="25" ratio="10">&gt;NAME</text>
-<text x="-1.27" y="-3.175" size="1.27" layer="27">&gt;VALUE</text>
-<rectangle x1="7.366" y1="-0.254" x2="7.874" y2="0.254" layer="51"/>
-<rectangle x1="4.826" y1="-0.254" x2="5.334" y2="0.254" layer="51"/>
-<rectangle x1="2.286" y1="-0.254" x2="2.794" y2="0.254" layer="51"/>
-<rectangle x1="-0.254" y1="-0.254" x2="0.254" y2="0.254" layer="51"/>
+<package name="1X04-SMD">
+<wire x1="5.08" y1="1.25" x2="-5.08" y2="1.25" width="0.127" layer="51"/>
+<wire x1="-5.08" y1="1.25" x2="-5.08" y2="-1.25" width="0.127" layer="51"/>
+<wire x1="-5.08" y1="-1.25" x2="-3.81" y2="-1.25" width="0.127" layer="51"/>
+<wire x1="-3.81" y1="-1.25" x2="-1.27" y2="-1.25" width="0.127" layer="51"/>
+<wire x1="-1.27" y1="-1.25" x2="1.27" y2="-1.25" width="0.127" layer="51"/>
+<wire x1="1.27" y1="-1.25" x2="3.81" y2="-1.25" width="0.127" layer="51"/>
+<wire x1="3.81" y1="-1.25" x2="5.08" y2="-1.25" width="0.127" layer="51"/>
+<wire x1="5.08" y1="-1.25" x2="5.08" y2="1.25" width="0.127" layer="51"/>
+<wire x1="3.81" y1="-1.25" x2="3.81" y2="-7.25" width="0.127" layer="51"/>
+<wire x1="1.27" y1="-1.25" x2="1.27" y2="-7.25" width="0.127" layer="51"/>
+<wire x1="-1.27" y1="-1.25" x2="-1.27" y2="-7.25" width="0.127" layer="51"/>
+<wire x1="-3.81" y1="-1.25" x2="-3.81" y2="-7.25" width="0.127" layer="51"/>
+<smd name="4" x="3.81" y="5" dx="3" dy="1" layer="1" rot="R90"/>
+<smd name="3" x="1.27" y="5" dx="3" dy="1" layer="1" rot="R90"/>
+<smd name="2" x="-1.27" y="5" dx="3" dy="1" layer="1" rot="R90"/>
+<smd name="1" x="-3.81" y="5" dx="3" dy="1" layer="1" rot="R90"/>
+<hole x="-2.54" y="0" drill="1.4"/>
+<hole x="2.54" y="0" drill="1.4"/>
 </package>
 </packages>
 </library>
@@ -223,18 +231,21 @@ We've spent an enormous amount of time creating and checking these footprints an
 &lt;br&gt;&lt;br&gt;
 You are welcome to use this library for commercial purposes. For attribution, we ask that when you begin to sell your device using our footprint, you email us with a link to the product being sold. We want bragging rights that we helped (in a very small part) to create your 8th world wonder. We would like the opportunity to feature your device on our homepage.</description>
 <packages>
-<package name="AXIAL-0.4">
-<description>1/4W Resistor, 0.4" wide&lt;p&gt;
-
-Yageo CFR series &lt;a href="http://www.yageo.com/pdf/yageo/Leaded-R_CFR_2008.pdf"&gt;http://www.yageo.com/pdf/yageo/Leaded-R_CFR_2008.pdf&lt;/a&gt;</description>
-<wire x1="-3.15" y1="-1.2" x2="-3.15" y2="1.2" width="0.2032" layer="21"/>
-<wire x1="-3.15" y1="1.2" x2="3.15" y2="1.2" width="0.2032" layer="21"/>
-<wire x1="3.15" y1="1.2" x2="3.15" y2="-1.2" width="0.2032" layer="21"/>
-<wire x1="3.15" y1="-1.2" x2="-3.15" y2="-1.2" width="0.2032" layer="21"/>
-<pad name="P$1" x="-5.08" y="0" drill="0.9" diameter="1.8796"/>
-<pad name="P$2" x="5.08" y="0" drill="0.9" diameter="1.8796"/>
-<text x="-3.175" y="1.905" size="0.8128" layer="25" font="vector" ratio="15">&gt;Name</text>
-<text x="-2.286" y="-0.381" size="0.8128" layer="21" font="vector" ratio="15">&gt;Value</text>
+<package name="0603-RES">
+<wire x1="-1.473" y1="0.983" x2="1.473" y2="0.983" width="0.0508" layer="39"/>
+<wire x1="1.473" y1="0.983" x2="1.473" y2="-0.983" width="0.0508" layer="39"/>
+<wire x1="1.473" y1="-0.983" x2="-1.473" y2="-0.983" width="0.0508" layer="39"/>
+<wire x1="-1.473" y1="-0.983" x2="-1.473" y2="0.983" width="0.0508" layer="39"/>
+<wire x1="-0.356" y1="0.432" x2="0.356" y2="0.432" width="0.1016" layer="51"/>
+<wire x1="-0.356" y1="-0.419" x2="0.356" y2="-0.419" width="0.1016" layer="51"/>
+<smd name="1" x="-0.85" y="0" dx="1.1" dy="1" layer="1"/>
+<smd name="2" x="0.85" y="0" dx="1.1" dy="1" layer="1"/>
+<text x="-0.889" y="0.762" size="0.4064" layer="25" font="vector">&gt;NAME</text>
+<text x="-1.016" y="-1.143" size="0.4064" layer="27" font="vector">&gt;VALUE</text>
+<rectangle x1="-0.8382" y1="-0.4699" x2="-0.3381" y2="0.4801" layer="51"/>
+<rectangle x1="0.3302" y1="-0.4699" x2="0.8303" y2="0.4801" layer="51"/>
+<rectangle x1="-0.1999" y1="-0.3" x2="0.1999" y2="0.3" layer="35"/>
+<rectangle x1="-0.2286" y1="-0.381" x2="0.2286" y2="0.381" layer="21"/>
 </package>
 </packages>
 </library>
@@ -420,12 +431,12 @@ design rules under a new name.</description>
 </pass>
 </autorouter>
 <elements>
-<element name="JP5" library="SparkFun-Connectors" package="BTA" value="BTA" x="10" y="9"/>
-<element name="JP1" library="SparkFun-Connectors" package="1X04_NO_SILK_ALL_ROUND" value="" x="2" y="30.38" rot="R270"/>
-<element name="JP2" library="SparkFun-Connectors" package="1X04_NO_SILK_ALL_ROUND" value="" x="17.24" y="30.38" rot="R270"/>
-<element name="JP3" library="SparkFun-Connectors" package="1X04_NO_SILK_ALL_ROUND" value="" x="4.54" y="38"/>
-<element name="R1" library="SparkFun-Passives" package="AXIAL-0.4" value="" x="5" y="27" rot="R90"/>
-<element name="R2" library="SparkFun-Passives" package="AXIAL-0.4" value="" x="14" y="27" rot="R270"/>
+<element name="JP5" library="SparkFun-Connectors" package="BTA" value="BTA" x="10" y="2.5"/>
+<element name="JP1" library="SparkFun-Connectors" package="1X04-SMD" value="" x="2" y="22.38" rot="R270"/>
+<element name="JP2" library="SparkFun-Connectors" package="1X04-SMD" value="" x="18.24" y="22.38" rot="R90"/>
+<element name="JP3" library="SparkFun-Connectors" package="1X04-SMD" value="" x="10.04" y="34.5" rot="R180"/>
+<element name="R1" library="SparkFun-Passives" package="0603-RES" value="" x="2.5" y="14"/>
+<element name="R2" library="SparkFun-Passives" package="0603-RES" value="" x="18.5" y="14.5" rot="R270"/>
 </elements>
 <signals>
 <signal name="N$7">
@@ -479,53 +490,68 @@ design rules under a new name.</description>
 <signal name="5V">
 <contactref element="JP3" pad="2"/>
 <contactref element="JP5" pad="5"/>
-<contactref element="R1" pad="P$2"/>
-<contactref element="R2" pad="P$1"/>
-<wire x1="7.08" y1="38" x2="7.08" y2="34.5" width="0.6096" layer="1"/>
-<wire x1="7.08" y1="34.5" x2="7.08" y2="34.16" width="0.6096" layer="1"/>
-<wire x1="7.08" y1="34.16" x2="5" y2="32.08" width="0.6096" layer="1"/>
-<wire x1="14" y1="32.08" x2="9.5" y2="32.08" width="0.6096" layer="1"/>
-<wire x1="9.5" y1="32.08" x2="7.08" y2="34.5" width="0.6096" layer="1"/>
-<wire x1="9.5" y1="32.08" x2="9.5" y2="18.75" width="0.6096" layer="1"/>
-<wire x1="9.5" y1="18.75" x2="8.75" y2="18" width="0.6096" layer="1"/>
+<contactref element="R1" pad="2"/>
+<contactref element="R2" pad="1"/>
+<wire x1="18.5" y1="15.35" x2="15.875" y2="15.35" width="0.4064" layer="1"/>
+<wire x1="15.875" y1="15.35" x2="15.875" y2="27.305" width="0.4064" layer="1"/>
+<wire x1="15.875" y1="27.305" x2="11.303" y2="27.305" width="0.4064" layer="1"/>
+<wire x1="11.303" y1="27.305" x2="11.303" y2="27.178" width="0.4064" layer="1"/>
+<wire x1="11.303" y1="27.178" x2="11.31" y2="27.178" width="0.4064" layer="1"/>
+<wire x1="11.31" y1="27.178" x2="11.31" y2="29.5" width="0.4064" layer="1"/>
+<wire x1="15.875" y1="15.35" x2="8.75" y2="15.35" width="0.4064" layer="1"/>
+<wire x1="8.75" y1="15.35" x2="8.75" y2="11.5" width="0.4064" layer="1"/>
+<wire x1="3.35" y1="14" x2="3.35" y2="15.35" width="0.4064" layer="1"/>
+<wire x1="3.35" y1="15.35" x2="8.75" y2="15.35" width="0.4064" layer="1"/>
 </signal>
 <signal name="S1">
 <contactref element="JP3" pad="3"/>
 <contactref element="JP5" pad="6"/>
-<wire x1="7.25" y1="15" x2="7.25" y2="16.25" width="0.6096" layer="16"/>
-<wire x1="7.25" y1="16.25" x2="6.5" y2="17" width="0.6096" layer="16"/>
-<wire x1="6.5" y1="17" x2="6.5" y2="19.5" width="0.6096" layer="16"/>
-<wire x1="6.5" y1="19.5" x2="8" y2="21" width="0.6096" layer="16"/>
-<wire x1="8" y1="21" x2="8" y2="36.38" width="0.6096" layer="16"/>
-<wire x1="8" y1="36.38" x2="9.62" y2="38" width="0.6096" layer="16"/>
+<wire x1="6" y1="16.764" x2="9.144" y2="16.764" width="0.4064" layer="16"/>
+<via x="9.144" y="16.764" extent="1-16" drill="0.6" shape="square"/>
+<wire x1="9" y1="29" x2="9" y2="29.5" width="0.4064" layer="1"/>
+<wire x1="9" y1="29.5" x2="8.77" y2="29.5" width="0.4064" layer="1"/>
+<wire x1="9.144" y1="16.764" x2="9.144" y2="29" width="0.4064" layer="1"/>
+<wire x1="9.144" y1="29" x2="9" y2="29" width="0.4064" layer="1"/>
+<wire x1="7.25" y1="8.5" x2="6" y2="8.5" width="0.4064" layer="16"/>
+<wire x1="6" y1="8.5" x2="6" y2="16.764" width="0.4064" layer="16"/>
+<wire x1="6" y1="16.764" x2="5.996" y2="16.764" width="0.4064" layer="16"/>
+<wire x1="9.017" y1="28.238" x2="9.017" y2="29.5" width="0.4064" layer="1"/>
+<wire x1="9.017" y1="29.5" x2="9" y2="29.5" width="0.4064" layer="1"/>
+<wire x1="9" y1="29.5" x2="9" y2="30" width="0.4064" layer="1"/>
 </signal>
 <signal name="S2">
 <contactref element="JP3" pad="4"/>
 <contactref element="JP5" pad="1"/>
-<wire x1="12.16" y1="38" x2="12.16" y2="20.59" width="0.6096" layer="16"/>
-<wire x1="12.16" y1="20.59" x2="14.75" y2="18" width="0.6096" layer="16"/>
+<wire x1="14.75" y1="11.5" x2="14.75" y2="16.764" width="0.4064" layer="16"/>
+<wire x1="14.75" y1="16.764" x2="14.478" y2="16.764" width="0.4064" layer="16"/>
+<via x="14.478" y="16.764" extent="1-16" drill="0.6" shape="square"/>
+<wire x1="14.478" y1="16.764" x2="11.303" y2="16.764" width="0.4064" layer="1"/>
+<wire x1="11.303" y1="16.764" x2="11.303" y2="26" width="0.4064" layer="1"/>
+<wire x1="11.303" y1="26" x2="10" y2="26" width="0.4064" layer="1"/>
+<wire x1="10" y1="26" x2="10" y2="32.004" width="0.4064" layer="1"/>
+<wire x1="10" y1="32.004" x2="6.223" y2="32.004" width="0.4064" layer="1"/>
+<wire x1="6.223" y1="32.004" x2="6.223" y2="29.5" width="0.4064" layer="1"/>
+<wire x1="6.223" y1="29.5" x2="6.23" y2="29.5" width="0.4064" layer="1"/>
 </signal>
 <signal name="N$1">
 <contactref element="JP5" pad="4"/>
-<contactref element="R1" pad="P$1"/>
-<wire x1="5" y1="21.92" x2="5" y2="13.5" width="0.6096" layer="1"/>
-<wire x1="5" y1="13.5" x2="6.5" y2="12" width="0.6096" layer="1"/>
-<wire x1="6.5" y1="12" x2="9" y2="12" width="0.6096" layer="1"/>
-<wire x1="9" y1="12" x2="10.5" y2="13.5" width="0.6096" layer="1"/>
-<wire x1="10.5" y1="13.5" x2="10.5" y2="14.75" width="0.6096" layer="1"/>
-<wire x1="10.5" y1="14.75" x2="10.25" y2="15" width="0.6096" layer="1"/>
+<contactref element="R1" pad="1"/>
+<wire x1="10.25" y1="8.5" x2="10.25" y2="3.75" width="0.4064" layer="1"/>
+<wire x1="10.25" y1="3.75" x2="10" y2="3.5" width="0.4064" layer="1"/>
+<wire x1="10" y1="3.5" x2="8.819" y2="3.5" width="0.4064" layer="1"/>
+<wire x1="8.819" y1="3.5" x2="1.651" y2="10.668" width="0.4064" layer="1"/>
+<wire x1="1.651" y1="10.668" x2="1.651" y2="13.999" width="0.4064" layer="1"/>
+<wire x1="1.651" y1="13.999" x2="1.65" y2="14" width="0.4064" layer="1"/>
 </signal>
 <signal name="N$3">
-<contactref element="R2" pad="P$2"/>
+<contactref element="R2" pad="2"/>
 <contactref element="JP5" pad="3"/>
-<wire x1="11.75" y1="18" x2="11.75" y2="19.67" width="0.6096" layer="1"/>
-<wire x1="11.75" y1="19.67" x2="14" y2="21.92" width="0.6096" layer="1"/>
+<wire x1="11.75" y1="11.5" x2="11.75" y2="13.65" width="0.4064" layer="1"/>
+<wire x1="11.75" y1="13.65" x2="18.5" y2="13.65" width="0.4064" layer="1"/>
 </signal>
-<signal name="N$5">
-<via x="5" y="35" extent="1-16" drill="0.9" diameter="1.9304"/>
+<signal name="N$2">
 </signal>
-<signal name="N$6">
-<via x="10" y="35" extent="1-16" drill="0.9" diameter="1.9304"/>
+<signal name="N$4">
 </signal>
 </signals>
 </board>


### PR DESCRIPTION
31-1-2016: Matthew Daiter <mdaiter8121@gmail.com>

Changed the EAGLE schematic for the RCH12.brd/sch to use SMD instead of PTH for electrical contact.

Files modified:
RHC12-BTA.brd
RHC12-BTA.sch

Parts modified:
R1
R2
All jumpers except for BTA connector.

Possible points of complication:
Was unable to find a BTA connector with a SMD connector. Don't know what you want to do about that.

Possible further optimizations:
Can now make board size smaller. Didn't want to modify form factor due to possible complications with electro-mechanical interface.